### PR TITLE
Do not require win32 apps to define EMB_DLL

### DIFF
--- a/embaland/platform.h
+++ b/embaland/platform.h
@@ -86,5 +86,5 @@ typedef unsigned __int64 uint64_t;
 #else
 #include <stdint.h>
 #endif
-#endif // !defined(EMB_NO_STDINT_H)
+#endif /* !defined(EMB_NO_STDINT_H) */
 #endif

--- a/embaland/platform.h
+++ b/embaland/platform.h
@@ -8,13 +8,13 @@
  */
 
 /**
- * @def EMB_DLL
- * Must be defined by applications that are linking against the DLL version of
- * the embaland library
+ * @def EMB_STATIC
+ * Must be defined by applications that are linking against the static version
+ * of the embaland library
  */
 
-#if defined(EMB_DLL) && defined(_EMB_BUILD_DLL)
-#error "You must not have both EMB_DLL and _EMB_BUILD_DLL defined"
+#if defined(EMB_STATIC) && defined(_EMB_BUILD_DLL)
+#error "You must not have both EMB_STATIC and _EMB_BUILD_DLL defined"
 #endif
 
 /**
@@ -33,7 +33,7 @@
 /* We are building embaland as a Win32 DLL */
 #define EMB_API __declspec(dllexport)
 #define EMB_LOCAL
-#elif (defined(_WIN32) || defined(__CYGWIN__)) && defined(EMB_DLL)
+#elif (defined(_WIN32) || defined(__CYGWIN__)) && !defined(EMB_STATIC)
 /* We are calling embaland as Win32 DLL */
 #define EMB_API __declspec(dllimport)
 #define EMB_LOCAL

--- a/emtriangle/Makefile.am
+++ b/emtriangle/Makefile.am
@@ -1,4 +1,4 @@
-noinst_PROGRAMS += emtriangle/emtriangle
+bin_PROGRAMS += emtriangle/emtriangle
 emtriangle_emtriangle_SOURCES = emtriangle/entry.c
 emtriangle_emtriangle_LDADD = emtriangle/libemtriangle.la\
 			      libembaland.la $(GLFW_LIBS) $(VULKAN_LIBS)


### PR DESCRIPTION
I am assuming that all applications will use a shared version of the
library by default. If they want to use static version than they must define
EMB_STATIC macro before including embaland headers.